### PR TITLE
Adjust init script for btc-explorer

### DIFF
--- a/pages/bitcoin/blockchain-explorer.en-US.mdx
+++ b/pages/bitcoin/blockchain-explorer.en-US.mdx
@@ -389,7 +389,7 @@ start_stop_daemon_args="--stdout ${BTCRPCEXPL_LOGDIR}/debug.log
 depend() {
     need bitcoind
 
-    if service_started fulcrum; then
+    if service_started "fulcrum"; then
         need fulcrum
     else
         need electrs

--- a/pages/bitcoin/blockchain-explorer.en-US.mdx
+++ b/pages/bitcoin/blockchain-explorer.en-US.mdx
@@ -389,11 +389,11 @@ start_stop_daemon_args="--stdout ${BTCRPCEXPL_LOGDIR}/debug.log
 depend() {
     need bitcoind
 
-    if service_started "fulcrum"; then
-        need fulcrum
-    else
-        need electrs
-    fi
+    use fulcrum
+    use electrs
+
+    after fulcrum
+    after electrs
 }
 
 start_pre() {


### PR DESCRIPTION
I was having issues where the explorer wouldn't start, even though fulcrum was up and running.

My initial attempt to "quote" fulcrum was a red herring. It was the act of modifying the script and then getting it to start that made it pass. Basically there is some caching, I think the `need` thing caches.

The issue is that it does not cache past shutdown, so when restarting, the fulcrum service was starting AFTER the btc-rpc-explorer and so it would not find fulcrum and add a `need` requirement for electrs.

This change seems to ensure that it all runs in the correct order and does not seem to crash even though I don't have `electrs` installed.